### PR TITLE
Set frontView frame in expanding animation *after* calling prepareExpandingView.

### DIFF
--- a/Xpandr/DAExpandAnimation.swift
+++ b/Xpandr/DAExpandAnimation.swift
@@ -118,8 +118,8 @@ class DAExpandAnimation: NSObject, UIViewControllerAnimatedTransitioning {
         // Add the expanding view to the scene.
         collapsedFrame = backgroundView.convertRect(collapsedFrame, toView: inView)
         if isPresentation {
-            frontView.frame = collapsedFrame
             toViewAnimationsAdapter?.prepareExpandingView?(frontView)
+            frontView.frame = collapsedFrame
         } else {
             toViewAnimationsAdapter?.prepareCollapsingView?(frontView)
         }


### PR DESCRIPTION
Set frontView frame in expanding animation _after_ calling prepareExpandingView (animation adapter might want to work with the original frame, for instance for creating a snapshot view...). 
